### PR TITLE
allow KC13 dust models through check_params

### DIFF
--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -917,8 +917,8 @@ class ParameterSet(object):
         NZ = driver.get_nz()
         assert self._params["zmet"] in range(1, NZ + 1), \
             "zmet={0} out of range [1, {1}]".format(self._params["zmet"], NZ)
-        assert self._params["dust_type"] in range(4), \
-            "dust_type={0} out of range [0, 3]".format(
+        assert self._params["dust_type"] in range(5), \
+            "dust_type={0} out of range [0, 4]".format(
                 self._params["dust_type"])
         assert self._params["imf_type"] in range(6), \
             "imf_type={0} out of range [0, 5]".format(self._params["imf_type"])


### PR DESCRIPTION
KC13 model requires dust_type = 4-- apparently no one has tried to use these yet...!
